### PR TITLE
Refactor: Simplify project setup and improve developer experience

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,15 +26,24 @@ git clone https://github.com/mahdikiani/FastAPILaunchpad.git
 cd FastAPILaunchpad
 ```
 
-### 2. Build and Run with Docker Compose
+### 2. Environment Variables
+
+Copy the sample environment file and customize it if needed:
+
+```bash
+cp sample.env .env
+```
+Update `DOMAIN` in `.env` to `localhost` for local development. Other variables like `PROJECT_NAME` can be set as per your project.
+
+### 3. Build and Run with Docker Compose
 
 ```bash
 docker-compose up --build
 ```
 
-This command will build the Docker image and run the containers as specified in your `docker-compose.yml` file. Your FastAPI application will be available at `http://localhost:8000`.
+This command will build the Docker image and run the container as specified in your `docker-compose.yml` file. Your FastAPI application will be available directly at `http://localhost:8000`.
 
-### 3. Accessing the API
+### 4. Accessing the API
 
 Navigate to `http://localhost:8000/docs` in your web browser to view the automatic interactive API documentation provided by Swagger UI.
 
@@ -42,11 +51,63 @@ Navigate to `http://localhost:8000/docs` in your web browser to view the automat
 
 ### Database Configuration
 
-You can configure your database connection in the `config.py` file. This boilerplate is compatible with various ORMs and supports both SQL and NoSQL options.
+Database connection settings are managed in `app/server/config.py`. This boilerplate is designed to be flexible and can be adapted to various SQL and NoSQL databases by modifying the ORM setup and connection strings in this file. Refer to the comments and structure within `app/server/config.py` for more details on customization.
 
 ### Traefik Configuration
 
-To deploy with Traefik, ensure you have Traefik set up on your deployment server or environment. Modify the `traefik.yml` file according to your specific deployment requirements.
+Traefik is optional for local development but recommended for production deployments as a reverse proxy and for managing SSL certificates.
+
+For production, you can:
+*   Create a separate `docker-compose.traefik.yml` or `traefik.yml` file that includes Traefik service definitions and the necessary labels for the `app` service.
+*   Alternatively, re-integrate the Traefik labels into the main `docker-compose.yml`. The original `docker-compose.yml` (before the simplification for local development) can serve as a reference for the required labels and network configurations. You can find previous versions in the Git history.
+
+### Debugging
+
+The `app/Dockerfile` is configured to run the application using `CMD ["python", "app.py"]` by default. For debugging:
+
+1.  Modify the `app/Dockerfile` to use the `debugpy` command. Comment out the current `CMD` and uncomment the one for debugging:
+    ```dockerfile
+    # CMD [ "python","app.py" ]
+    CMD ["python", "-m" ,"debugpy", "--listen", "0.0.0.0:3000", "-m", "app"]
+    ```
+2.  Rebuild the Docker image:
+    ```bash
+    docker-compose build app
+    ```
+    Or, if you prefer to rebuild and restart:
+    ```bash
+    docker-compose up --build
+    ```
+3.  Configure your IDE to attach to the debugger on port `3000`.
+
+## Running without Docker (Optional)
+
+While Docker is the recommended method for consistency and ease of deployment, you can also run the application locally without it:
+
+1.  **Create and activate a virtual environment:**
+    ```bash
+    python -m venv venv
+    source venv/bin/activate  # On Windows use `venv\Scripts\activate`
+    ```
+2.  **Install dependencies:**
+    ```bash
+    pip install -r app/requirements.txt
+    ```
+3.  **Set up environment variables:**
+    The application may rely on environment variables defined in `.env`. Ensure these are available in your shell. You can manually create a `.env` file (if you haven't already from the Docker setup) and load it using a library like `python-dotenv` if you modify `app/app.py` or manage them through your shell. For example, your `.env` could look like:
+    ```
+    PROJECT_NAME=my_project
+    DOMAIN=localhost
+    TESTING=false
+    # Add other necessary variables
+    ```
+4.  **Run the application:**
+    ```bash
+    python app/app.py
+    ```
+    The application should be available at `http://localhost:8000`.
+
+**Note:** Using Docker is highly recommended to ensure a consistent environment across development, testing, and production.
 
 ### Continuous Integration
 

--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -12,5 +12,6 @@ FROM fast-base as fast-server
 USER user
 COPY --chown=user:user . .
 
-CMD ["python", "-m" ,"debugpy", "--listen", "0.0.0.0:3000", "-m", "app"]
-# CMD [ "python","app.py" ]
+# CMD ["python", "-m" ,"debugpy", "--listen", "0.0.0.0:3000", "-m", "app"]
+# For debugging, comment out the CMD below and uncomment the CMD above.
+CMD [ "python","app.py" ]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,20 +4,5 @@ services:
     restart: unless-stopped
     env_file:
       - .env
-    networks:
-      - traefik-net
-    labels:
-      - "traefik.enable=true"
-      - "traefik.http.routers.${PROJECT_NAME}.entrypoints=web"
-      - "traefik.http.routers.${PROJECT_NAME}.rule=Host(`${DOMAIN}`)"
-      # - "traefik.http.routers.${PROJECT_NAME}.middlewares=https-redirect"
-      - "traefik.http.routers.${PROJECT_NAME}-secure.entrypoints=websecure"
-      - "traefik.http.routers.${PROJECT_NAME}-secure.rule=Host(`${DOMAIN}`)"
-      - "traefik.http.routers.${PROJECT_NAME}-secure.tls=true"
-      - "traefik.http.routers.${PROJECT_NAME}-secure.tls.certresolver=letsencrypt"
-      - "traefik.http.services.${PROJECT_NAME}.loadbalancer.server.port=8000"
-      - "traefik.docker.network=traefik-net"
-
-networks:
-  traefik-net:
-    external: true
+    ports:
+      - "8000:8000"


### PR DESCRIPTION
This commit introduces several changes to make it easier for new developers like you to get started with the project:

- **Simplified Docker Compose:** The `docker-compose.yml` has been modified to remove Traefik configurations by default for local development. It now directly maps port 8000, making the application accessible at `http://localhost:8000` without additional setup.
- **Default .env file:** A `.env` file is now created by copying `sample.env` with `DOMAIN` preset to `localhost`, ensuring a working default configuration.
- **Simplified Dockerfile:** The default `CMD` in `app/Dockerfile` has been changed to `python app.py` for a more straightforward run experience. Instructions for enabling `debugpy` are included as comments.
- **Improved README:** The `README.md` has been extensively updated to reflect these changes. It now includes:
    - Clearer instructions for getting started with Docker.
    - Guidance on database configuration.
    - Information on how to use Traefik for production (and that it's optional locally).
    - A new section on enabling debugging with `debugpy`.
    - A new section on running the application locally without Docker, including virtual environment setup and dependency installation.

These changes aim to reduce initial friction and provide clearer pathways for both local development and understanding deployment options.